### PR TITLE
Improve format specifier parsing.

### DIFF
--- a/pyfmt_test.go
+++ b/pyfmt_test.go
@@ -88,6 +88,7 @@ func TestSingleFormat(t *testing.T) {
 		{"{}", "☺", "☺"},
 		{"{:t}", "", "string"},
 		{"asdf{:10}", "1234", "asdf      1234"},
+		{"{:💩^10}", "poop", "💩💩💩poop💩💩💩"},
 
 		// Integer tests
 		{"{}", 42, "42"},

--- a/render.go
+++ b/render.go
@@ -69,10 +69,10 @@ func splitFlags(flags string) (align, sign, radix, zeroPad, minWidth, precision,
 	for i := 0; i < end; {
 		switch state {
 		case alignState:
-			if flags[i] == '<' || flags[i] == '>' || flags[i] == '=' || flags[i] == '^' {
-				i += 1
-			} else if end > 1 && (flags[1] == '<' || flags[1] == '>' || flags[1] == '=' || flags[1] == '^') {
+			if end > 1 && (flags[1] == '<' || flags[1] == '>' || flags[1] == '=' || flags[1] == '^') {
 				i += 2
+			} else if flags[i] == '<' || flags[i] == '>' || flags[i] == '=' || flags[i] == '^' {
+				i += 1
 			}
 			// TODO(slongfield): Support arbitrary runes as alignment characters.
 			align = flags[0:i]
@@ -82,7 +82,7 @@ func splitFlags(flags string) (align, sign, radix, zeroPad, minWidth, precision,
 				sign = flags[i : i+1]
 				i += 1
 			}
-			state = widthState
+			state = radixState
 		case radixState:
 			if flags[i] == '#' {
 				radix = flags[i : i+1]

--- a/render.go
+++ b/render.go
@@ -61,8 +61,7 @@ var isDigit = map[byte]struct{}{
 	'5': struct{}{}, '6': struct{}{}, '7': struct{}{}, '8': struct{}{}, '9': struct{}{},
 }
 
-// splitFlags splits out the flags into the various fields. This replaces the previous regex parser
-// (see render_test.go for regex)
+// splitFlags splits out the flags into the various fields.
 func splitFlags(flags string) (align, sign, radix, zeroPad, minWidth, precision, verb string, err error) {
 	end := len(flags)
 	if end == 0 {
@@ -72,12 +71,15 @@ func splitFlags(flags string) (align, sign, radix, zeroPad, minWidth, precision,
 	for i := 0; i < end; {
 		switch state {
 		case alignState:
-			if end > 1 && (flags[1] == '<' || flags[1] == '>' || flags[1] == '=' || flags[1] == '^') {
-				i += 2
-			} else if flags[i] == '<' || flags[i] == '>' || flags[i] == '=' || flags[i] == '^' {
-				i += 1
+			if flags[i] == '<' || flags[i] == '>' || flags[i] == '=' || flags[i] == '^' {
+				i = 1
 			}
-			// TODO(slongfield): Support arbitrary runes as alignment characters.
+			if end > 1 {
+				_, size := utf8.DecodeRuneInString(flags)
+				if flags[size] == '<' || flags[size] == '>' || flags[size] == '=' || flags[size] == '^' {
+					i = size + 1
+				}
+			}
 			align = flags[0:i]
 			state = signState
 		case signState:

--- a/render.go
+++ b/render.go
@@ -65,6 +65,9 @@ var isDigit = map[byte]struct{}{
 // (see render_test.go for regex)
 func splitFlags(flags string) (align, sign, radix, zeroPad, minWidth, precision, verb string, err error) {
 	end := len(flags)
+	if end == 0 {
+		return
+	}
 	state := alignState
 	for i := 0; i < end; {
 		switch state {

--- a/render.go
+++ b/render.go
@@ -37,6 +37,9 @@ func (r *render) clearFlags() {
 	r.flags = flags{}
 }
 
+// From profiling the benchmarks, this regex is responsible for most of both the allocations and
+// the memory use (~75%), and not an insignificant amount of the run time. Replacing it with a
+// hand-written NFA would probably significantly help performance.
 var flagPattern = regexp.MustCompile(`\A((?:.[<>=^])|(?:[<>=^])?)([\+\- ]?)(#?)(0?)(\d*)(\.\d*)?([bdoxXeEfFgGrts%]?)\z`)
 
 func (r *render) parseFlags(flags string) error {
@@ -149,8 +152,7 @@ func (r *render) render() error {
 		r.minWidth = ""
 	}
 
-	str := fmt.Sprintf(strings.Join([]string{
-		"%", r.sign, radix, r.minWidth, r.precision, r.renderVerb}, ""), r.val)
+	str := fmt.Sprintf("%"+r.sign+radix+r.minWidth+r.precision+r.renderVerb, r.val)
 
 	if prefix != "" {
 		// Get rid of any prefix added by minWidth. We'll add this back in later when we

--- a/render_test.go
+++ b/render_test.go
@@ -7,30 +7,41 @@ import (
 	"testing"
 )
 
+const flagRegex = `\A((?:.[<>=^])|(?:[<>=^])?)([\+\- ]?)(#?)(0?)(\d*)(\.\d*)?([bdoxXeEfFgGrts%]?)\z`
+
 func TestSplitFlags(t *testing.T) {
-	tests := []string{"", "4<", "+=", "^10.3", ":> #010.4X", "<0%", "10.10E", "#x", "<<", "=="}
-	var flagPattern = regexp.MustCompile(`\A((?:.[<>=^])|(?:[<>=^])?)([\+\- ]?)(#?)(0?)(\d*)(\.\d*)?([bdoxXeEfFgGrts%]?)\z`)
+	var flagPattern = regexp.MustCompile(flagRegex)
+
+	tests := []string{"", "4<", "+=", "^10.3", ":> #010.4X",
+		"<0%", "10.10E", "#x", "<<", "==", "💩<"}
 
 	for _, test := range tests {
 		align, sign, radix, zeroPad, minWidth, precision, verb, err := splitFlags(test)
 
 		if err != nil {
-			t.Error(Error("splitFlags({}) errored: {}!", test, err))
+			t.Error(Must("splitFlags({}) errored: {}!", test, err))
 		}
 
 		if !flagPattern.MatchString(test) {
-			t.Error(Error("Could not match with regex!: {}", test))
+			t.Error(Must("Could not match with regex!: {}", test))
 		}
 
 		got := []string{test, align, sign, radix, zeroPad, minWidth, precision, verb}
 		want := flagPattern.FindStringSubmatch(test)
 		if !reflect.DeepEqual(got, want) {
-			t.Error(Error("splitFlags({}) = \n{:r} Want: \n{:r}", test, got, want))
+			t.Error(Must("splitFlags({}) = \n{:r} Want: \n{:r}", test, got, want))
 		}
 	}
 }
 
 func TestSplitFlagsError(t *testing.T) {
+	tests := []string{"<><>", "asdf", "^^^", "^#xx", ":>  #010.4x"}
+	for _, test := range tests {
+		_, _, _, _, _, _, _, err := splitFlags(test)
+		if err == nil {
+			t.Error(Must("splitFlags({}) did not error!", test))
+		}
+	}
 }
 
 func TestParseFlags(t *testing.T) {
@@ -53,16 +64,16 @@ func TestParseFlags(t *testing.T) {
 	for _, test := range tests {
 		defer func() {
 			if r := recover(); r != nil {
-				t.Error(Error("parseFlags({flagStr}) paniced: {1}", test, r))
+				t.Error(Must("parseFlags({flagStr}) paniced: {1}", test, r))
 			}
 		}()
 		r := render{}
 		err := r.parseFlags(test.flagStr)
 		if err != nil {
-			t.Error(Error("parseFlags({flagStr}) Errored: {1}", test, err))
+			t.Error(Must("parseFlags({flagStr}) Errored: {1}", test, err))
 		}
 		if !reflect.DeepEqual(test.want, r.flags) {
-			t.Error(Error("parseFlags({flagStr}) Got: \n{1:s} Want \n{want:s}", test, r.flags))
+			t.Error(Must("parseFlags({flagStr}) Got: \n{1:s} Want \n{want:s}", test, r.flags))
 		}
 	}
 }
@@ -80,16 +91,16 @@ func TestParseFlagsError(t *testing.T) {
 	for _, test := range tests {
 		defer func() {
 			if r := recover(); r != nil {
-				t.Error(Error("parseFlags({flagStr}) paniced: {1}", test, r))
+				t.Error(Must("parseFlags({flagStr}) paniced: {1}", test, r))
 			}
 		}()
 		r := render{}
 		err := r.parseFlags(test.flagStr)
 		if err == nil {
-			t.Error(Error("parseFlags({flagStr}) did not raise an error", test))
+			t.Error(Must("parseFlags({flagStr}) did not raise an error", test))
 		}
 		if !strings.Contains(err.Error(), test.want) {
-			t.Error(Error("parseFlags({flagStr}) raised {1}, missing want string {want}", test, err))
+			t.Error(Must("parseFlags({flagStr}) raised {1}, missing want string {want}", test, err))
 		}
 	}
 }

--- a/render_test.go
+++ b/render_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSplitFlags(t *testing.T) {
-	tests := []string{"", "4<", "+=", "^10.3", ":> #010.4X", "<0%", "10.10E", "#x"}
+	tests := []string{"", "4<", "+=", "^10.3", ":> #010.4X", "<0%", "10.10E", "#x", "<<", "=="}
 	var flagPattern = regexp.MustCompile(`\A((?:.[<>=^])|(?:[<>=^])?)([\+\- ]?)(#?)(0?)(\d*)(\.\d*)?([bdoxXeEfFgGrts%]?)\z`)
 
 	for _, test := range tests {
@@ -25,7 +25,7 @@ func TestSplitFlags(t *testing.T) {
 		got := []string{test, align, sign, radix, zeroPad, minWidth, precision, verb}
 		want := flagPattern.FindStringSubmatch(test)
 		if !reflect.DeepEqual(got, want) {
-			t.Error(Error("splitFlags({}) = {} Want: {}", test, got, want))
+			t.Error(Error("splitFlags({}) = \n{:r} Want: \n{:r}", test, got, want))
 		}
 	}
 }

--- a/render_test.go
+++ b/render_test.go
@@ -2,9 +2,36 @@ package pyfmt
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+func TestSplitFlags(t *testing.T) {
+	tests := []string{"", "4<", "+=", "^10.3", ":> #010.4X", "<0%", "10.10E", "#x"}
+	var flagPattern = regexp.MustCompile(`\A((?:.[<>=^])|(?:[<>=^])?)([\+\- ]?)(#?)(0?)(\d*)(\.\d*)?([bdoxXeEfFgGrts%]?)\z`)
+
+	for _, test := range tests {
+		align, sign, radix, zeroPad, minWidth, precision, verb, err := splitFlags(test)
+
+		if err != nil {
+			t.Error(Error("splitFlags({}) errored: {}!", test, err))
+		}
+
+		if !flagPattern.MatchString(test) {
+			t.Error(Error("Could not match with regex!: {}", test))
+		}
+
+		got := []string{test, align, sign, radix, zeroPad, minWidth, precision, verb}
+		want := flagPattern.FindStringSubmatch(test)
+		if !reflect.DeepEqual(got, want) {
+			t.Error(Error("splitFlags({}) = {} Want: {}", test, got, want))
+		}
+	}
+}
+
+func TestSplitFlagsError(t *testing.T) {
+}
 
 func TestParseFlags(t *testing.T) {
 	tests := []struct {
@@ -65,5 +92,4 @@ func TestParseFlagsError(t *testing.T) {
 			t.Error(Error("parseFlags({flagStr}) raised {1}, missing want string {want}", test, err))
 		}
 	}
-
 }


### PR DESCRIPTION
From earlier benchmarks, format specifier regex used up the most memory, and the most time, and a lot of that was spent backtracking, which is completely unnecessary for this regex. Changed it into an explicit state machine, which gives about a 5x speedup relative to the regex engine.