### PR TITLE
Skip flag processing for empty flags.

### DIFF
--- a/pyfmt.go
+++ b/pyfmt.go
@@ -13,6 +13,12 @@ type buffer struct {
 	stage    []byte
 }
 
+// Implements the io.Writer interface
+func (b *buffer) Write(p []byte) (n int, err error) {
+	b.contents = append(b.contents, p...)
+	return len(p), nil
+}
+
 // WriteString writes a string into the backing buffer.
 func (b *buffer) WriteString(s string) {
 	b.contents = append(b.contents, s...)

--- a/render.go
+++ b/render.go
@@ -17,6 +17,7 @@ type flags struct {
 	precision  string
 	renderVerb string
 	percent    bool
+	empty      bool
 }
 
 // Render is the renderer used to render dispatched format strings into a buffer that's been set up
@@ -143,6 +144,7 @@ func splitFlags(flags string) (align, sign, radix, zeroPad, minWidth, precision,
 func (r *render) parseFlags(flags string) error {
 	r.renderVerb = "v"
 	if flags == "" {
+		r.empty = true
 		return nil
 	}
 	align, sign, radix, zeroPad, minWidth, precision, verb, err := splitFlags(flags)
@@ -220,6 +222,11 @@ func (r *render) render() error {
 	var prefix, radix string
 	var width int64
 	var err error
+	if r.empty {
+		fmt.Fprint(r.buf, r.val)
+		return nil
+	}
+
 	if r.percent {
 		if err = r.setupPercent(); err != nil {
 			return err

--- a/render_test.go
+++ b/render_test.go
@@ -49,7 +49,7 @@ func TestParseFlags(t *testing.T) {
 		flagStr string
 		want    flags
 	}{
-		{"", flags{renderVerb: "v"}},
+		{"", flags{renderVerb: "v", empty: true}},
 		{">>", flags{fillChar: '>', align: right, renderVerb: "v"}},
 		{">10.10", flags{align: right, minWidth: "10", precision: ".10", renderVerb: "v"}},
 		{"#x", flags{showRadix: true, renderVerb: "x"}},


### PR DESCRIPTION
Speeds things up a bit, especially when there are a lot of empty flags and we can avoid some allocs.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkPrintEmptyParallel-8     14.2          14.1          -0.70%
BenchmarkFmtForComparison-8       6.17          6.16          -0.16%
BenchmarkCenteredParallel-8       122           122           +0.00%
BenchmarkLargeString-8            61284         40791         -33.44%
BenchmarkFmtLargeString-8         8011          8161          +1.87%
BenchmarkComplexFormat-8          257           257           +0.00%

benchmark                         old allocs     new allocs     delta
BenchmarkPrintEmptyParallel-8     0              0              +0.00%
BenchmarkFmtForComparison-8       0              0              +0.00%
BenchmarkCenteredParallel-8       3              3              +0.00%
BenchmarkLargeString-8            2002           1002           -49.95%
BenchmarkFmtLargeString-8         1              1              +0.00%
BenchmarkComplexFormat-8          13             13             +0.00%

benchmark                         old bytes     new bytes     delta
BenchmarkPrintEmptyParallel-8     0             0             +0.00%
BenchmarkFmtForComparison-8       0             0             +0.00%
BenchmarkCenteredParallel-8       132           132           +0.00%
BenchmarkLargeString-8            24144         20136         -16.60%
BenchmarkFmtLargeString-8         13583         13583         +0.00%
BenchmarkComplexFormat-8          344           344           +0.00%
```
