### PR TITLE
Fix known mismatch when switching numbering types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ names build off of simple names.
 
 The simplest look up treats the argument list as just a list. There are two possible ways to look up
 elements from this list. First, by {}, which gets the 'next' item and by {n}, which gets the nth
-item. Accessing these two ways is independent, and
+item. Accessing these two ways is independent but cannot be mixed, and
 
 ```
   pyfmt.Must("{} {} {}", ...)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/slongfield/pyfmt
 
-go 1.5
+go 1.9

--- a/pyfmt_test.go
+++ b/pyfmt_test.go
@@ -35,7 +35,6 @@ func TestBasicFormat(t *testing.T) {
 		{"{2}", []interface{}{"a", "b", "c"}, "c"},
 		{"{[1]}", []interface{}{[]string{"a", "b", "c"}}, "b"},
 		{"{[2]}", []interface{}{[]string{"a", "b", "c"}}, "c"},
-		{"{}{1}", []interface{}{"你好", "世界"}, "你好世界"},
 		{"{}", []interface{}{1}, "1"},
 		{"{}", []interface{}{int8(-1)}, "-1"},
 		{"{}", []interface{}{uint8(1)}, "1"},

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,6 +19,9 @@ build/__init__.py: *.py build/
 	pip3 install -r requirements.txt;
 	touch .venv/touchfile
 
+.PHONY: debug-check
+debug-check: .venv/touchfile build/libbridge.so build/__init__.py
+	. .venv/bin/activate; pytest -s --hypothesis-show-statistics --hypothesis-verbosity=debug
 
 .PHONY: check
 check: .venv/touchfile build/libbridge.so build/__init__.py


### PR DESCRIPTION
This simplifies the hypothesis testing substantially, since now the
error conditions match.